### PR TITLE
Make it more likely that the source code editor doesn't stretch beyon…

### DIFF
--- a/webapp/public/style_domjudge.css
+++ b/webapp/public/style_domjudge.css
@@ -746,6 +746,6 @@ blockquote {
 
 .editor {
     width: 100%;
-    height: 80vh;
+    height: 75vh;
     border: 1px solid grey;
 }


### PR DESCRIPTION
…d the screen.

----

Example: 
![image](https://github.com/user-attachments/assets/62a125cb-010e-4a5e-bb33-6f00ba42aa92)
